### PR TITLE
Fix compile error with node_binder module

### DIFF
--- a/node_binder/node_http_fetcher.cc
+++ b/node_binder/node_http_fetcher.cc
@@ -84,7 +84,7 @@ void NodeHttpFetcher::Cancel(int request_id) {
 
 void NodeHttpFetcher::OnRequestComplete(int request_id) {
   DCHECK(CalledOnValidThread());
-  impl_->OnTaskComplete(request_id);
+  impl_->ReleaseRequest(request_id);
 }
 
 }  // namespace stellite


### PR DESCRIPTION
https://github.com/line/stellite/issues/68
resolve above

Cause:
9c0c92e2ec01f474d96f06c115e696477e715697 [9c0c92e]
http_fetcher.h
Api was changed.